### PR TITLE
More accurate regexp

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var pattern = /^\$2[aby]\$\d+\$.+$/;
+var pattern = /^\$2[abxy]\$([0][4-9]|[1-2][0-9]|[3][0-1])\$[0-9a-zA-Z\.\/]{53}$/;
 
 module.exports = {
   isHash: function(needle) {


### PR DESCRIPTION
Bcrypt identifier : $2[abxy]$
Salt rounds  : 04 to 31
Salt : 22 Radix64 chars
Resulting hash :  31 Radix64 chars

Sources :
https://github.com/kelektiv/node.bcrypt.js/blob/master/src/bcrypt.cc
https://en.wikipedia.org/wiki/Bcrypt